### PR TITLE
Update adaptec-ld-discovery.sh

### DIFF
--- a/files/hwraid-adaptec/scripts/adaptec-ld-discovery.sh
+++ b/files/hwraid-adaptec/scripts/adaptec-ld-discovery.sh
@@ -3,7 +3,7 @@
 # Description:	Logical drives auto-discovery via arcconf. (TESTED WITH V5.20 (B17414))
 
 adp_list=$(sudo arcconf getversion |grep -w "^Controller" |cut -d# -f2)
-ld_list=$(for a in $adp_list; do sudo arcconf getconfig $a ld |grep -w "Logical device number" |awk '{print $4}' |while read ld ; do echo $a:$ld; done ; done)
+ld_list=$(for a in $adp_list; do sudo arcconf getconfig $a ld |grep -w "Logical Device number" |awk '{print $4}' |while read ld ; do echo $a:$ld; done ; done)
 
 if [[ $1 = raw ]]; then
   for ld in ${ld_list}; do echo $ld; done ; exit 0


### PR DESCRIPTION
arcconf getconfig 1 ld | grep -w "Logical device number" 
nothing is found
arcconf getconfig 1 ld | grep -w "Logical Device number" 
Logical Device number 0
Logical Device number 1
Logical Device number 2
